### PR TITLE
Fix SyntaxError: duplicate update_header kwarg in RandomControlSourcePathReceiver

### DIFF
--- a/src/forcefinder/rattlesnake_control_laws/spr_random_control_law.py
+++ b/src/forcefinder/rattlesnake_control_laws/spr_random_control_law.py
@@ -354,7 +354,7 @@ class RandomControlSourcePathReceiver(PowerSourcePathReceiver):
         if self.inverse_settings['ISE_technique'].lower() == 'auto_tikhonov_by_l_curve':
             self.auto_tikhonov_by_l_curve(use_transformation=False, update_header=False, **inverse_arguments)
         elif self.inverse_settings['ISE_technique'].lower() == 'auto_truncation_by_l_curve':
-            self.auto_truncation_by_l_curve(use_transformation=False, update_header=False, update_header=False, **inverse_arguments)
+            self.auto_truncation_by_l_curve(use_transformation=False, update_header=False, **inverse_arguments)
         elif self.inverse_settings['ISE_technique'].lower() == 'auto_tikhonov_by_cv_rse':
             self.auto_tikhonov_by_cv_rse(use_transformation=False, update_header=False, **inverse_arguments)
         elif self.inverse_settings['ISE_technique'].lower() == 'manual_inverse':


### PR DESCRIPTION
The `auto_truncation_by_l_curve` dispatch branch in `RandomControlSourcePathReceiver.system_id_update` passes `update_header=False` twice. Repeated keyword arguments are a `SyntaxError` at compile time (line 357), so the entire `spr_random_control_law` module fails to import — breaking every ISE technique, not just `auto_truncation_by_l_curve`. This removes the duplicate.

Found while running the SPR random control law as a Rattlesnake control law; verified the module compiles and the `auto_tikhonov_by_l_curve` path runs end-to-end in headless Rattlesnake simulations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)