### PR TITLE
Cvxpy import fix. Double argument fix within rattlesnake control laws.

### DIFF
--- a/src/forcefinder/__init__.py
+++ b/src/forcefinder/__init__.py
@@ -19,8 +19,11 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
+# cvxpy must be included before PyQt5 within .transient_gui_plot
+# as the second import messes with a .dll for some reason
+import cvxpy  # noqa: F401
 from .transient_quality_evaluation import transient_quality_metrics
-from .transient_quality_evaluation.transient_gui_plot import SpectrogramGUI, LevelErrorGUI 
+from .transient_quality_evaluation.transient_gui_plot import SpectrogramGUI, LevelErrorGUI
 from .core.source_path_receiver import (LinearSourcePathReceiver,
                                         PowerSourcePathReceiver,
                                         TransientSourcePathReceiver)

--- a/src/forcefinder/rattlesnake_control_laws/spr_random_control_law.py
+++ b/src/forcefinder/rattlesnake_control_laws/spr_random_control_law.py
@@ -354,7 +354,7 @@ class RandomControlSourcePathReceiver(PowerSourcePathReceiver):
         if self.inverse_settings['ISE_technique'].lower() == 'auto_tikhonov_by_l_curve':
             self.auto_tikhonov_by_l_curve(use_transformation=False, update_header=False, **inverse_arguments)
         elif self.inverse_settings['ISE_technique'].lower() == 'auto_truncation_by_l_curve':
-            self.auto_truncation_by_l_curve(use_transformation=False, update_header=False, update_header=False, **inverse_arguments)
+            self.auto_truncation_by_l_curve(use_transformation=False, update_header=False, **inverse_arguments)
         elif self.inverse_settings['ISE_technique'].lower() == 'auto_tikhonov_by_cv_rse':
             self.auto_tikhonov_by_cv_rse(use_transformation=False, update_header=False, **inverse_arguments)
         elif self.inverse_settings['ISE_technique'].lower() == 'manual_inverse':


### PR DESCRIPTION
This patch fixes an issue with cvxpy not playing well with PyQt5 when they both import the same .dll at some point within their python import statements. cvxpy must be imported first in the forcefinder __init__.py file for this to not crash the kernel. This fix was verified with forcefinder import statements and running the rattlesnake control laws. 

This patch also fixes a typo in the rattlesnake control law where update_header was provided as a duplicate argument.